### PR TITLE
Modular mitigation methods

### DIFF
--- a/app/reporting/run_demo.py
+++ b/app/reporting/run_demo.py
@@ -141,11 +141,19 @@ def main():
     # BEFORE (baseline) — copy everything compute_report_metrics provides
     report.update(base)
 
+    # Detect method (temporary heuristic)
+    if args.csv_after and "smote" in args.csv_after.lower():
+        method_used = "SMOTE oversampling"
+    elif args.csv_after and "ctgan" in args.csv_after.lower():
+        method_used = "CTGAN female oversampling"
+    else:
+        method_used = "Unknown mitigation"
+        
     # AFTER (mitigation) — map to _syn fields expected by the template
     if after:
         report.update(
             {
-                "method_name": "CTGAN female oversampling",
+                "method_name": method_used,
                 "pct_female_syn": after.get("pct_female", "N/A"),
                 "auroc_m_syn": after.get("auroc_m", "N/A"),
                 "auroc_f_syn": after.get("auroc_f", "N/A"),

--- a/app/synthetic/balance_data.py
+++ b/app/synthetic/balance_data.py
@@ -1,0 +1,67 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+
+from ctgan import CTGAN
+from imblearn.over_sampling import SMOTE
+
+def balance_with_ctgan(df, target_ratio, epochs, seed):
+    df_f = df[df["sex"] == "F"].copy()
+    if df_f.empty:
+        raise ValueError("No female rows available to learn from.")
+
+    ctgan = CTGAN(epochs=epochs, verbose=True)
+    ctgan.fit(df_f, discrete_columns=["sex", "label"])
+
+    n = len(df)
+    n_f = (df["sex"] == "F").sum()
+    needed_f = int(round(target_ratio * n)) - n_f
+    syn_f = ctgan.sample(needed_f)
+
+    syn_f["sex"] = "F"
+    syn_f["label"] = syn_f["label"].round().clip(0, 1).astype(int)
+    syn_f["score"] = syn_f["score"].clip(0.0, 1.0)
+
+    return pd.concat([df, syn_f], ignore_index=True)
+
+def balance_with_smote(df):
+    df_copy = df.copy()
+    X = df_copy.drop(columns=["sex"])
+    y = df_copy["sex"]
+
+    smote = SMOTE()
+    X_res, y_res = smote.fit_resample(X, y)
+
+    df_bal = pd.DataFrame(X_res)
+    df_bal["sex"] = y_res
+    return df_bal
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    p.add_argument("--out", required=True)
+    p.add_argument("--method", choices=["ctgan", "smote"], default="ctgan")
+    p.add_argument("--target_ratio", type=float, default=0.5)
+    p.add_argument("--epochs", type=int, default=300)
+    p.add_argument("--seed", type=int, default=42)
+    args = p.parse_args()
+
+    np.random.seed(args.seed)
+    df = pd.read_csv(args.csv, comment="#", on_bad_lines="skip", engine="python")
+    df["sex"] = df["sex"].astype(str).str.upper().str[0].map({"M": "M", "F": "F"}).fillna("O")
+
+    if args.method == "ctgan":
+        df_bal = balance_with_ctgan(df, args.target_ratio, args.epochs, args.seed)
+    elif args.method == "smote":
+        df_bal = balance_with_smote(df)
+    else:
+        raise ValueError(f"Unsupported method: {args.method}")
+
+    df_bal = df_bal.sample(frac=1.0, random_state=args.seed).reset_index(drop=True)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    df_bal.to_csv(args.out, index=False)
+    print(f"[OK] Wrote balanced CSV to {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/reports/EquityReport_template.md
+++ b/reports/EquityReport_template.md
@@ -33,7 +33,7 @@ Status: {{baseline_status}} (PASS or FAIL)
 
 ## 3) After Mitigation (Synthetic Balance)
 
-Method applied: {{method_name}} (example: CTGAN female oversampling)
+Method applied: {{method_name}}
 
 | Metric              | Male            | Female          | Gap (F-M, pp)     | Threshold |
 |---------------------|-----------------|-----------------|-------------------|-----------|


### PR DESCRIPTION
**Add modular mitigation support (SMOTE + CTGAN)**

This PR extends the data balancing pipeline to support multiple mitigation methods.

### What's New
- Added `balance_data.py`:
  - Supports both `--method ctgan` (original approach) and `--method smote` (new).
  - Modular structure = makes it easy to plug in future methods.
- Updated `run_demo.py`: 
  - Detects the mitigation method and labels the report accordingly.
- Small change to `EquityReport_template.md`: 
  - Removed hardcoded CTGAN example from the method label.

### Why 
- CTGAN is powerful, but sometimes not necessary for small datasets.
- SMOTE provides a lightweight, familiar oversampling method for ML workflows.
- By modularizing, the project can now grow to include multiple fairness interventions.

### Example Usage
```bash
python app/synthetic/balance_data.py \
  --csv data/imbalanced.csv \
  --out data/synthetic/balanced_smote.csv \
  --method smote
